### PR TITLE
Bearer token command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ home directory. In the config file the user can specify the following parameters
 [im_client]
 # only set one of the urls
 #xmlrpc_url=http://localhost:8899
-restapi_url==http://localhost:8800
+restapi_url=http://localhost:8800
 auth_file=auth.dat
 xmlrpc_ssl_ca_certs=/tmp/pki/ca-chain.pem
 ```

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ keys are:
 
 * ``token`` indicates the OpenID token associated to the credential. This field is used in the OCCI plugin. 
 
+* ``bearer_token_command`` command used to obtain the access token when the token is not specified. 
+  This command is useful when the lifetime of the token is short, avoiding editing the authentication file each time. 
+
 ##### OpenStack addicional fields
 
 OpenStack has a set of addicional fields to access a cloud site:

--- a/auth.dat
+++ b/auth.dat
@@ -1,5 +1,7 @@
 id = one; type = OpenNebula; host = server:2633; username = user; password = pass
 type = InfrastructureManager; username = user; password = pass
+type = InfrastructureManager; token = user-token
+type = InfrastructureManager; bearer_token_command = oidc-token OIDC_ACCOUNT
 type = VMRC; host = http://server:8080/vmrc; username = user; password = pass
 id = ec2; type = EC2; username = ACESS_KEY; password = SECRET_KEY
 id = gce; type = GCE; username = CLIENT_ID; password = CLIENT_SECRET; project = project-name

--- a/im_client.py
+++ b/im_client.py
@@ -285,19 +285,12 @@ def read_auth_data(filename):
 def fetch_bearer_token(cmd):
     proc = subprocess.Popen(cmd.split(' '), stdout=subprocess.PIPE, 
                                             stderr=subprocess.PIPE)
-    try:
-        outs, errs = proc.communicate(timeout=15)
-        if proc.returncode != 0:
-            if errs == b'':
-                errs = outs
-            raise Exception("Failed to get bearer token using %s: %s" % (cmd, errs.decode('utf-8')))
-        return outs.decode('utf-8').replace('\n', '')
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        outs, errs = proc.communicate()
+    outs, errs = proc.communicate()
+    if proc.returncode != 0:
         if errs == b'':
             errs = outs
-        raise Exception("Timeout when getting bearer token using %s: %s" % (cmd, errs.decode('utf-8')))
+        raise Exception("Failed to get bearer token using %s: %s" % (cmd, errs.decode('utf-8')))
+    return outs.decode('utf-8').replace('\n', '')
 
 
 def get_inf_id(args):


### PR DESCRIPTION
Hi,

This upgrade would allow the im_client to fetch automatically the token from a command line command.
(Normally using [oidc-agent](https://indigo-dc.gitbook.io/oidc-agent/)) 

## Why
Because some tokens have a very short live and it is a bit tedious to change the auth.dat file every time.

## Notes
It is inspired on rclone basis, we use it to mount webdav.
[rclone-webdav](https://rclone.org/webdav/)

I did the following changes:
 - Edit the im_client.py addind the functionality
 - Edit README with a bit of information
 - Add an example to the auth.dat provided

I did NOT run the unittest, it is needed a local instance of IM (quite long to configure).
However I tested it against [appsgrycap](https://appsgrycap.i3m.upv.es:31443/im-dashboard/settings) and looks fine.

Please run the tests you consider in order to check nothing is broken.
